### PR TITLE
Add FastAPI backend and Vue frontend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# My Project
-this is a test11111.
+# Shift Maker
+
+This repository contains a minimal FastAPI backend and Vue.js frontend.
+
+## Requirements
+- Python 3.11+
+- Node.js 18+
+- npm
+
+## Backend setup
+1. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. Start the development server:
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+
+## Frontend setup
+1. Change into the frontend directory and install dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, world!"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Vue</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^5.0.0"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <h1>Hello Vue!</h1>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+</style>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()]
+})


### PR DESCRIPTION
## Summary
- add minimal FastAPI app with root endpoint
- scaffold Vue project structure with Vite configuration
- document setup steps for backend and frontend

## Testing
- `python -m py_compile backend/main.py`
- `pip install fastapi uvicorn` *(fails: Tunnel connection failed 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-vue)*

------
https://chatgpt.com/codex/tasks/task_e_68989ccaaba0832e952c9cc14691f6b9