### PR TITLE
Add schedule API and Vue table

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,11 @@
+"""FastAPI application entry point."""
+from fastapi import FastAPI
+from .routers import schedules
+
+app = FastAPI()
+app.include_router(schedules.router)
+
+
+@app.get("/")
+def read_root():
+    return {"message": "Shift maker API"}

--- a/backend/app/routers/schedules.py
+++ b/backend/app/routers/schedules.py
@@ -1,0 +1,39 @@
+"""Router for schedule-related endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pathlib import Path
+import json
+
+router = APIRouter(prefix="/schedules", tags=["schedules"])
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "data" / "latest_schedule.json"
+
+
+def load_latest_schedule() -> dict:
+    """Load the latest schedule from the data file.
+
+    Returns
+    -------
+    dict
+        Parsed JSON data. If the data file does not exist, an empty
+        dictionary is returned.
+    """
+    if DATA_FILE.exists():
+        with DATA_FILE.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+@router.get("/latest")
+def get_latest_schedule() -> dict:
+    """Return the latest shift result.
+
+    The returned JSON includes:
+        * members for each date
+        * assignment counts for members
+        * number of committee members
+        * gender statistics
+        * unapplied rules
+    """
+    return load_latest_schedule()

--- a/backend/data/latest_schedule.json
+++ b/backend/data/latest_schedule.json
@@ -1,0 +1,18 @@
+{
+  "dates": {
+    "2024-05-01": ["Alice", "Bob"],
+    "2024-05-02": ["Carol", "Dave"]
+  },
+  "assign_count": {
+    "Alice": 1,
+    "Bob": 1,
+    "Carol": 1,
+    "Dave": 1
+  },
+  "committee_count": 2,
+  "gender_count": {
+    "male": 2,
+    "female": 2
+  },
+  "unapplied_rules": ["Rule X", "Rule Y"]
+}

--- a/frontend/src/components/ScheduleTable.vue
+++ b/frontend/src/components/ScheduleTable.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <h2>Schedule</h2>
+    <table v-if="schedule.dates">
+      <thead>
+        <tr><th>Date</th><th>Members</th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="(members, date) in schedule.dates" :key="date">
+          <td>{{ date }}</td>
+          <td>{{ members.join(', ') }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Statistics</h3>
+    <div v-if="schedule.assign_count">
+      <h4>Assignment Count</h4>
+      <ul>
+        <li v-for="(count, member) in schedule.assign_count" :key="member">
+          {{ member }}: {{ count }}
+        </li>
+      </ul>
+    </div>
+    <div v-if="schedule.committee_count !== undefined">
+      <p>Committee Members: {{ schedule.committee_count }}</p>
+    </div>
+    <div v-if="schedule.gender_count">
+      <p>Male: {{ schedule.gender_count.male }} / Female: {{ schedule.gender_count.female }}</p>
+    </div>
+    <div v-if="schedule.unapplied_rules && schedule.unapplied_rules.length">
+      <h4>Unapplied Rules</h4>
+      <ul>
+        <li v-for="rule in schedule.unapplied_rules" :key="rule">{{ rule }}</li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const schedule = ref({})
+
+onMounted(async () => {
+  const res = await fetch('/schedules/latest')
+  if (res.ok) {
+    schedule.value = await res.json()
+  }
+})
+</script>


### PR DESCRIPTION
## Summary
- add FastAPI route to fetch latest schedule data
- add Vue component to display schedule and stats

## Testing
- `pytest`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898a1f603b8832ea92c59be9e7004d4