### PR TITLE
Add backend tests and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package containing member API and shift generation service."""

--- a/backend/member_api.py
+++ b/backend/member_api.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class Member:
+    """Simple representation of a member."""
+
+    name: str
+
+
+class MemberAPI:
+    """In-memory API to manage members."""
+
+    def __init__(self) -> None:
+        self._members: Dict[str, Member] = {}
+
+    def add_member(self, name: str) -> Member:
+        """Add a new member.
+
+        Raises:
+            ValueError: If the member already exists.
+        """
+
+        if name in self._members:
+            raise ValueError("Member already exists")
+        member = Member(name=name)
+        self._members[name] = member
+        return member
+
+    def list_members(self) -> List[Member]:
+        """Return all registered members."""
+
+        return list(self._members.values())

--- a/backend/shift_service.py
+++ b/backend/shift_service.py
@@ -1,0 +1,41 @@
+from typing import Dict, Iterable, List
+
+from .member_api import Member
+
+
+def generate_shifts(
+    members: List[Member],
+    days: Iterable[str],
+    max_shifts_per_member: int = 1,
+) -> Dict[str, Member]:
+    """Assign members to days respecting a maximum per member.
+
+    Args:
+        members: Members available for shifts.
+        days: Iterable of day identifiers.
+        max_shifts_per_member: Maximum shifts allowed per member.
+
+    Returns:
+        Mapping of day to assigned member.
+
+    Raises:
+        ValueError: If assignments cannot be made.
+    """
+
+    members = list(members)
+    if not members:
+        raise ValueError("No members provided")
+
+    schedule: Dict[str, Member] = {}
+    counts: Dict[str, int] = {m.name: 0 for m in members}
+    idx = 0
+    for day in days:
+        # Find next available member respecting the max limit
+        available = [m for m in members if counts[m.name] < max_shifts_per_member]
+        if not available:
+            raise ValueError("No available member for assignment")
+        member = available[idx % len(available)]
+        schedule[day] = member
+        counts[member.name] += 1
+        idx += 1
+    return schedule

--- a/backend/tests/test_member_api.py
+++ b/backend/tests/test_member_api.py
@@ -1,0 +1,18 @@
+import pytest
+
+from ..member_api import MemberAPI
+
+
+def test_add_and_list_members():
+    api = MemberAPI()
+    api.add_member("Alice")
+    api.add_member("Bob")
+    names = [m.name for m in api.list_members()]
+    assert names == ["Alice", "Bob"]
+
+
+def test_add_member_duplicate():
+    api = MemberAPI()
+    api.add_member("Alice")
+    with pytest.raises(ValueError):
+        api.add_member("Alice")

--- a/backend/tests/test_shift_service.py
+++ b/backend/tests/test_shift_service.py
@@ -1,0 +1,27 @@
+import pytest
+
+from ..member_api import MemberAPI
+from ..shift_service import generate_shifts
+
+
+def test_generate_shifts_respects_constraints():
+    api = MemberAPI()
+    api.add_member("Alice")
+    api.add_member("Bob")
+    members = api.list_members()
+    days = ["Mon", "Tue", "Wed", "Thu"]
+    schedule = generate_shifts(members, days, max_shifts_per_member=2)
+    counts = {m.name: 0 for m in members}
+    for day, member in schedule.items():
+        counts[member.name] += 1
+    assert set(schedule.keys()) == set(days)
+    assert all(count <= 2 for count in counts.values())
+
+
+def test_generate_shifts_raises_with_insufficient_members():
+    api = MemberAPI()
+    api.add_member("Alice")
+    members = api.list_members()
+    days = ["Mon", "Tue"]
+    with pytest.raises(ValueError):
+        generate_shifts(members, days)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pre-commit
+black
+flake8


### PR DESCRIPTION
## Summary
- implement in-memory member API and shift generation service
- add pytest unit tests for API and shift scheduling
- configure pre-commit with black and flake8
- add GitHub Actions workflow to run lint and tests

## Testing
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pip install flake8` *(failed: Could not find a version that satisfies the requirement flake8)*
- `pre-commit run --all-files` *(failed: command not found)
- `flake8` *(failed: command not found)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898a1f834b0832ebd515c9f4e287c77