### PR TITLE
Fix frontend to display schedule data properly

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,12 @@
 <template>
-  <h1>Hello Vue!</h1>
+  <div>
+    <h1>Shift Maker</h1>
+    <ScheduleTable />
+  </div>
 </template>
 
 <script setup>
+import ScheduleTable from './components/ScheduleTable.vue'
 </script>
 
 <style scoped>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,11 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/schedules': 'http://localhost:8000',
+      '/shift-requests': 'http://localhost:8000'
+    }
+  }
 })


### PR DESCRIPTION
- Update App.vue to import and use ScheduleTable component
- Add Vite proxy configuration to connect frontend with backend API
- Enable proper display of shift schedule data from backend

🤖 Generated with [Claude Code](https://claude.ai/code)