### PR TITLE
fix: Configure Vite to allow external hosts and add PM2 configuration

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  apps: [
+    {
+      name: 'shift-maker-backend',
+      script: 'python',
+      args: '-m uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000',
+      cwd: '/home/user/webapp',
+      env: {
+        NODE_ENV: 'development'
+      }
+    },
+    {
+      name: 'shift-maker-frontend',
+      script: 'npm',
+      args: 'run dev -- --host 0.0.0.0 --port 5173',
+      cwd: '/home/user/webapp/frontend',
+      env: {
+        NODE_ENV: 'development'
+      }
+    }
+  ]
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,12 +4,16 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
+    allowedHosts: 'all',
     proxy: {
-      '/schedules': 'http://localhost:8001',
-      '/shift-requests': 'http://localhost:8001',
-      '/members': 'http://localhost:8001',
-      '/availabilities': 'http://localhost:8001',
-      '/shift-generation': 'http://localhost:8001'
+      '/schedules': 'http://localhost:8000',
+      '/shift-requests': 'http://localhost:8000',
+      '/members': 'http://localhost:8000',
+      '/availabilities': 'http://localhost:8000',
+      '/shift-generation': 'http://localhost:8000'
     }
   }
 })


### PR DESCRIPTION
## Changes Made

- Fixed Vite configuration to allow external hosts access by adding  and 
- Updated proxy settings to use correct backend port (8000 instead of 8001)
- Added PM2 ecosystem configuration for managing both backend and frontend services
- Backend: FastAPI service running on port 8000
- Frontend: Vue.js service running on port 5173

## Testing
- Both services are running successfully via PM2
- Frontend is now accessible via external URL
- Backend API is operational

## Technical Details
- Vite now binds to all interfaces (0.0.0.0) instead of localhost only
- allowedHosts set to 'all' to permit access from sandbox URLs
- PM2 configuration enables proper service management and monitoring